### PR TITLE
Add Firefox channel aliases

### DIFF
--- a/fftool/main.py
+++ b/fftool/main.py
@@ -2,8 +2,22 @@
 
 import argparse
 
-CHANNELS = ['gr', 'beta', 'aurora', 'nightly', 'ALL']
+CHANNELS = ['gr', 'release', 'stable', 'beta', 'aurora', 'devedition', 'developeredition', 'nightly', 'ALL']
 DEFAULT_CHANNEL = 'nightly'
+
+def get_channel(channel):
+    # Remap some channel names.
+    channels = {
+        'release': 'gr',
+        'stable': 'gr',
+        'devedition': 'aurora',
+        'developeredition': 'aurora'
+    }
+    if channel in channels:
+        return channels[channel]
+
+    return channel
+
 
 parser = argparse.ArgumentParser(prog='ff-tool')
 subparsers = parser.add_subparsers(help='commands', dest='command')
@@ -71,6 +85,8 @@ uninstall.add_argument(
 )
 
 options = parser.parse_args()
+if "channel" in options:
+    options.channel = get_channel(options.channel)
 
 if options.command == 'download':
     print("Downloading Firefox... [channel: {0}]".format(options.channel))


### PR DESCRIPTION
Adding a few channel aliases.

### Usage:
```sh
# Remap channel name if it is in alias lookup table.
$ ./main.py download -c release
Downloading Firefox... [channel: gr]
Namespace(channel='gr', command='download')
```

```sh
# Do nothing if no channel name alias was found in lookup table.
$ ./main.py download -c gr
Downloading Firefox... [channel: gr]
Namespace(channel='gr', command='download')
```

```sh
# fftool download command help now shows all channel names and aliases:
$ ./main.py download -h
usage: ff-tool download [-h]
                        [-c {gr,release,stable,beta,aurora,devedition,developeredition,nightly,ALL}]

optional arguments:
  -h, --help            show this help message and exit
  -c {gr,release,stable,beta,aurora,devedition,developeredition,nightly,ALL}, --channel {gr,release,stable,beta,aurora,devedition,developeredition,nightly,ALL}
                        Download a specific Firefox channel via mozdownload.
```

```sh
# If no channel is specified, we assume they want "nightly", because why not...
$ ./main.py download
Downloading Firefox... [channel: nightly]
Namespace(channel='nightly', command='download')
```

```sh
# We still display a handy error if the user specifies an unexpected channel.
$ ./main.py download -c unstable
usage: ff-tool download [-h]
                        [-c {gr,release,stable,beta,aurora,devedition,developeredition,nightly,ALL}]
ff-tool download: error: argument -c/--channel: invalid choice: 'unstable' (choose from 'gr', 'release', 'stable', 'beta', 'aurora', 'devedition', 'developeredition', 'nightly', 'ALL')
```