### PR TITLE
Use a single instance of Outlawg

### DIFF
--- a/fftool/__init__.py
+++ b/fftool/__init__.py
@@ -1,6 +1,8 @@
 import os
 from subprocess import Popen, PIPE
 from firefox_env_handler import IniHandler
+from outlawg import Outlawg
+
 
 __version__ = '0.0.1'
 
@@ -21,6 +23,8 @@ OS_CONFIG = IniHandler()
 OS_CONFIG.load_os_config('configs')
 
 PATH_PREFS_ROOT = os.environ.get('PATH_PREFS_ROOT')
+
+Log = Outlawg()
 
 
 def local(cmd):

--- a/fftool/firefox_download.py
+++ b/fftool/firefox_download.py
@@ -6,24 +6,19 @@ Module to download OS-specific versions of Firefox:
 4. Nightly (nightly)
 """
 
+import ConfigParser as configparser  # Python 2
 import os
 import time
 
-from fftool import DIR_TEMP_BROWSERS as BASE_DIR, OS_CONFIG as env
+from fftool import DIR_TEMP_BROWSERS as BASE_DIR, OS_CONFIG as env, Log
 from firefox_install import install, get_firefox_version
 from mozdownload import FactoryScraper
-from outlawg import Outlawg
-
-import ConfigParser as configparser  # Python 2
-
 
 CONFIG_CHANNELS = os.path.join('configs', 'channels.ini')
 SCRIPT_START_TIME = time.time()
 
 config = configparser.ConfigParser()
 config.read(CONFIG_CHANNELS)
-
-out = Outlawg()
 
 
 def modification_date(filename):
@@ -69,7 +64,7 @@ def download(channel):
         firefox_version = get_firefox_version(channel)
         args = {"channel": channel, "version": firefox_version}
         msg = "You have the latest version of {channel} installed ({version})."
-        out.header(msg.format(**args))
+        Log.header(msg.format(**args))
 
 
 def download_all():

--- a/fftool/firefox_env_handler.py
+++ b/fftool/firefox_env_handler.py
@@ -5,10 +5,9 @@ import platform
 import re
 import sys
 import ConfigParser as configparser  # Python 2
-
 from outlawg import Outlawg
 
-out = Outlawg()
+Log = Outlawg()
 
 
 class FirefoxEnvHandler():
@@ -72,7 +71,7 @@ class IniHandler(FirefoxEnvHandler):
         """
         Load an INI config based on the specified `ini_path`.
         """
-        out.header('LOADING {0}'.format(ini_path))
+        Log.header('LOADING {0}'.format(ini_path))
 
         # Make sure the specified config file exists, fail hard if missing.
         if not os.path.isfile(ini_path):
@@ -94,7 +93,7 @@ class IniHandler(FirefoxEnvHandler):
         Generate and save the output environment file so we can source it from
         something like .bashrc or .bashprofile.
         """
-        out.header('CREATING ENV FILE ({0})'.format(out_file))
+        Log.header('CREATING ENV FILE ({0})'.format(out_file))
 
         env_fmt = "export %s=\"%s\""
         env_vars = []

--- a/fftool/firefox_install.py
+++ b/fftool/firefox_install.py
@@ -2,12 +2,9 @@
 
 import os
 import stat
-from fftool import local
+from fftool import local, Log
 from firefox_env_handler import IniHandler
-from outlawg import Outlawg
 from fftool import DIR_TEMP_BROWSERS as BASE_DIR, OS_CONFIG as env
-
-out = Outlawg()
 
 
 def chmodx(path):
@@ -35,8 +32,8 @@ def install(channel):
             # Since Beta and General Release channels install
             # to the same directory, install Beta first then
             # rename the directory.
-            gr_install_dir = env.config.get('release', 'PATH_FIREFOX_APP')
-            local('mv {0} {1}'.format(gr_install_dir, install_dir))
+            release_install_dir = env.config.get('release', 'PATH_FIREFOX_APP')
+            local('mv {0} {1}'.format(release_install_dir, install_dir))
 
     elif IniHandler.is_mac():
         from hdiutil import extract_dmg
@@ -51,7 +48,7 @@ def install(channel):
         print("YOU FAIL")
         exit()
 
-    out.header("Installed {0} ({1})".format(firefox_version, channel))
+    Log.header("Installed {0} ({1})".format(firefox_version, channel))
 
 
 def get_firefox_version(channel):

--- a/fftool/firefox_profile.py
+++ b/fftool/firefox_profile.py
@@ -12,8 +12,7 @@ directory.
 import os
 from tempfile import mkdtemp
 from mozprofile import Profile, Preferences
-from outlawg import Outlawg
-from fftool import DIR_TEMP_PROFILES as BASE_PROFILE_DIR, PATH_PREFS_ROOT
+from fftool import DIR_TEMP_PROFILES as BASE_PROFILE_DIR, PATH_PREFS_ROOT, Log
 import ConfigParser as configparser  # Python 2
 
 
@@ -21,7 +20,6 @@ PATH_PREFS_GLOBAL = os.path.abspath('.')
 FILE_PREFS = 'prefs.ini'
 
 config = configparser.ConfigParser()
-out = Outlawg()
 
 
 def prefs_paths(application, test_type, env='stage'):
@@ -71,7 +69,7 @@ def create_mozprofile(profile_dir, application=None, test_type=None, env=None):
 
         if os.path.exists(full_profile_dir):
             msg = "WARNING: Profile '{0}' already exists. Merging configs."
-            out.header(msg.format(full_profile_dir), 'XL', '-')
+            Log.header(msg.format(full_profile_dir), 'XL', '-')
 
     prefs = Preferences()
 
@@ -85,7 +83,7 @@ def create_mozprofile(profile_dir, application=None, test_type=None, env=None):
     profile = Profile(
         profile=full_profile_dir, restore=False, preferences=prefs())
 
-    out.header("Launching browser with the following user configs:")
+    Log.header("Launching browser with the following user configs:")
     print(profile.summary())
 
     # this is the path to the created profile

--- a/fftool/firefox_run.py
+++ b/fftool/firefox_run.py
@@ -1,6 +1,6 @@
-from subprocess import Popen, PIPE
 from fftool import (
-    OS_CONFIG as env
+    OS_CONFIG as env,
+    local
 )
 
 
@@ -16,5 +16,6 @@ def launch_firefox(profile_path, channel):
         channel,
         profile_path)
     )
+
     cmd = '"{0}" -profile "{1}"'.format(FIREFOX_APP_BIN, profile_path)
-    Popen(cmd, stdout=PIPE, shell=True)
+    local(cmd)

--- a/fftool/main.py
+++ b/fftool/main.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
 
-from fftool import DEFAULT_CHANNEL, PATH_PREFS_ROOT
+from fftool import DEFAULT_CHANNEL, PATH_PREFS_ROOT, Log
 from ff_cli import ff_cli
 from firefox_download import download
 from firefox_profile import create_mozprofile
 from firefox_run import launch_firefox
-from outlawg import Outlawg
-
-out = Outlawg()
 
 
 def main():
@@ -16,7 +13,7 @@ def main():
     # If the user is trying to create application specific configs but didn't
     # specify their `$PATH_PREFS_ROOT` environment variable, exit early.
     if options.app and not PATH_PREFS_ROOT:
-        out.header("ERROR")
+        Log.header("ERROR")
         print("Missing path to $PATH_PREFS_ROOT directory.")
         print("Please set the `PATH_PREFS_ROOT` environment variable and " +
               "try again.")


### PR DESCRIPTION
Rather than create an Outlawg() reference for each command, add a global logger in \_\_init\_\_.py.
Also refactors a `Popen()` which we can now use our handy helper for.